### PR TITLE
Показывать кнопку 'Подтвердить' только после первой фотографии

### DIFF
--- a/lib/dialogue/service/init.rb
+++ b/lib/dialogue/service/init.rb
@@ -16,12 +16,8 @@ class Dialogue::Service::Init
   def call
     update => message: { from: from }
 
-    send_message from, text,
-      reply_markup: {
-        keyboard: [[Dialogue::Service::COMMIT]],
-        resize_keyboard: true,
-        one_time_keyboard: true
-      }
+    # Убираем reply_markup с кнопкой - она появится после первой фотографии
+    send_message from, text
 
     FSA::State::Transit[Dialogue::Service::PhotoAwait]
   end

--- a/lib/dialogue/service/photo_await.rb
+++ b/lib/dialogue/service/photo_await.rb
@@ -16,16 +16,12 @@ class Dialogue::Service::PhotoAwait
   def call
     case update
     in message: { photo: photo, from: from }
-      # Проверяем, была ли это первая фотография
-      was_first_photo = service.photos.count.zero?
-      
       service.update(
         photos: Sequel.pg_array([*service.photos, photo.max_by { it[:file_size] }.fetch(:file_id)])
       )
 
-      # Отправляем кнопку только после получения первой фотографии
-      if was_first_photo
-        send_message from, "Фотография получена! Можете добавить ещё или подтвердить завершение.",
+      if service.photos.count == 1
+        send_message from, "После отправки всех фотографий нажмите кнопку",
           reply_markup: {
             keyboard: [[Dialogue::Service::COMMIT]],
             resize_keyboard: true,

--- a/lib/dialogue/service/photo_await.rb
+++ b/lib/dialogue/service/photo_await.rb
@@ -15,20 +15,28 @@ class Dialogue::Service::PhotoAwait
 
   def call
     case update
-    in message: { photo: photo }
+    in message: { photo: photo, from: from }
+      # Проверяем, была ли это первая фотография
+      was_first_photo = service.photos.count.zero?
+      
       service.update(
         photos: Sequel.pg_array([*service.photos, photo.max_by { it[:file_size] }.fetch(:file_id)])
       )
 
+      # Отправляем кнопку только после получения первой фотографии
+      if was_first_photo
+        send_message from, "Фотография получена! Можете добавить ещё или подтвердить завершение.",
+          reply_markup: {
+            keyboard: [[Dialogue::Service::COMMIT]],
+            resize_keyboard: true,
+            one_time_keyboard: true
+          }
+      end
+
       FSA::State::Same[]
 
     in message: { text: Dialogue::Service::COMMIT, from: from } if service.photos.count.zero?
-      send_message from, "Нужно хотя бы одно изображение",
-        reply_markup: {
-          keyboard: [[Dialogue::Service::COMMIT]],
-          resize_keyboard: true,
-          one_time_keyboard: true
-        }
+      send_message from, "Нужно хотя бы одно изображение"
 
       FSA::State::Same[]
 


### PR DESCRIPTION
## Описание изменений

Изменена логика отображения кнопки "Подтвердить" в команде `/service`:

### До изменений:
- Кнопка "Подтвердить" отправлялась сразу при вызове команды `/service`
- Пользователь видел кнопку до загрузки фотографий

### После изменений:
- При вызове `/service` отправляется только текстовое сообщение без кнопки
- Кнопка "Подтвердить" появляется только после получения первой фотографии
- При получении первой фотографии пользователь видит подтверждающее сообщение и кнопку

## Измененные файлы:

1. **`lib/dialogue/service/init.rb`** - убрана отправка кнопки при инициализации диалога
2. **`lib/dialogue/service/photo_await.rb`** - добавлена логика отправки кнопки при получении первой фотографии

## Улучшения UX:

- Более интуитивный интерфейс: кнопка появляется только когда есть что подтверждать
- Устранена путаница пользователей, которые могли нажать "Подтвердить" до загрузки фотографий
- Добавлено информативное сообщение при получении первой фотографии

## Тестирование:

1. Вызвать команду `/service` - должно показаться только текстовое сообщение
2. Отправить первую фотографию - должна появиться кнопка "Подтвердить" с подтверждающим сообщением
3. Отправить еще фотографии - кнопка не должна дублироваться
4. Нажать "Подтвердить" - должна произойти публикация в канал