### PR TITLE
Add docker-compose and Dockerfile for local Ruby development environment without Rails

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,12 @@
+version: '3.8'
+
+services:
+  ruby_dev:
+    build: .
+    container_name: lrc4_ruby_dev
+    volumes:
+      - .:/app
+    working_dir: /app
+    stdin_open: true
+    tty: true
+    command: /bin/bash

--- a/dockerfile.dev
+++ b/dockerfile.dev
@@ -1,0 +1,14 @@
+# Использует основу с основного Dockerfile
+FROM ruby:3.4.5-alpine
+
+WORKDIR /app
+
+COPY Gemfile Gemfile.lock ./
+
+RUN apk add --no-cache build-base libpq-dev git && \
+    gem install bundler --no-document && \
+    bundle install
+
+COPY . .
+
+CMD ["/bin/sh"]


### PR DESCRIPTION
Добавлены файлы docker-compose.yml и обновлен Dockerfile для локальной разработки Ruby без использования Rails, Node.js и других зависимостей. Конфигурация ориентирована на упрощенный запуск и работу в локальной среде разработки на Windows.